### PR TITLE
Fix incorrect year in 10.0.2 patchReleaseDate

### DIFF
--- a/.github/releases.json
+++ b/.github/releases.json
@@ -51,7 +51,7 @@
     "10.0": {
       "tag": "v10.0.2",
       "minorReleaseDate": "2025-11-12T00:00:00.000Z",
-      "patchReleaseDate": "2025-04-14T00:00:00.000Z",
+      "patchReleaseDate": "2026-04-14T00:00:00.000Z",
       "supportedFrameworks": [
         "net10.0"
       ]


### PR DESCRIPTION
## Summary

Fixes the `patchReleaseDate` for the 10.0 release in `.github/releases.json`, which was set to `2025-04-14` instead of `2026-04-14`.

```diff
-      "patchReleaseDate": "2025-04-14T00:00:00.000Z",
+      "patchReleaseDate": "2026-04-14T00:00:00.000Z",
```

## Root cause

The release bot wasn't miscalculating dates — it was faithfully formatting a bad stored value. `documentation/releases.md` is regenerated from `.github/releases.json` (see `.github/actions/update-releases-md`), so the typo surfaced as a "2026 → 2025 regression" in the patch/End-of-Support date.

The `2025` typo was introduced in the manually-created release PR dotnet/dotnet-monitor#9242, whose description notes *"the automation is currently broken; this PR was manually created."* In that hand-made change the JSON got `2025` while the hand-edited markdown got the correct `2026`, hiding the typo until the markdown was auto-regenerated.

For reference, GitHub release `v10.0.2` was published `2026-04-20`, confirming the intended year is 2026. A `2025-04-14` patch date is also impossible since it predates the 10.0 minor release date of `2025-11-12`.

## Notes

`documentation/releases.md` already shows `April 14, 2026` (the correct, manually-set value), so no markdown change is needed — this fix simply makes the source JSON consistent so future regenerations keep producing 2026.