### PR TITLE
[SFI-ES5.2] Bump global.json .NET SDK pin to 10.0.109 to clear high-severity CG alert

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "tools": {
-    "dotnet": "10.0.108",
+    "dotnet": "10.0.109",
     "runtimes": {
       "aspnetcore": [
         "$(MicrosoftAspNetCoreApp80Version)",


### PR DESCRIPTION
## Summary

Updates the .NET SDK pinned in `global.json` from `10.0.108` to `10.0.109` to remediate a **high-severity** Component Governance / OSS vulnerability (SFI-ES5.2) flagged against `/global.json`.

`10.0.109` is the latest serviced **10.0.1xx** feature-band SDK (released **2026-06-09**), matching the repo's existing feature band. Verified against the [.NET 10.0.109 release notes](https://github.com/dotnet/core/blob/main/release-notes/10.0/10.0.9/10.0.109.md) and the [10.0 releases.json](https://raw.githubusercontent.com/dotnet/core/main/release-notes/10.0/releases.json) (`latest-release: 10.0.9`, security release).

## CVEs fixed

The `10.0.9` / SDK `10.0.109` security release addresses:

- **CVE-2026-45490** — .NET SDK elevation of privilege (**High**)
- **CVE-2026-45491**
- **CVE-2026-45591**

This clears the high-severity CG alert (`::10.0.101 10.0.101 -DotNet`, path `/global.json`).

## Change

Single-line, surgical edit — only the SDK `tools.dotnet` pin was changed. The `runtimes` MSBuild property references and `msbuild-sdks` entries are untouched.

```diff
   "tools": {
-    "dotnet": "10.0.108",
+    "dotnet": "10.0.109",
```

JSON validated as well-formed.