### PR TITLE
Update release approval group to NETMonitor alias

### DIFF
--- a/eng/pipelines/dotnet-monitor-publish.yml
+++ b/eng/pipelines/dotnet-monitor-publish.yml
@@ -48,9 +48,6 @@ resources:
 extends:
   template: /eng/pipelines/templates/pipeline-template.yml@self
   parameters:
-    featureFlags:
-      sbomtoolkitPipelineRunnerGenerationEnabled: false
-      sbomtoolkitPipelineRunnerValidationEnabled: false
     networkIsolationPolicy: Permissive
     sdl:
       sbom:

--- a/eng/pipelines/stages/preparerelease.yml
+++ b/eng/pipelines/stages/preparerelease.yml
@@ -89,16 +89,19 @@ stages:
             --client-id "$env:servicePrincipalId"
             -v True
 
-      # SBOM generation is handled by 1ES PT at publish time: the 1ES.PublishPipelineArtifact
-      # task below auto-generates an SBOM (_manifest) over the published AssetsLayout, which
-      # includes the staged package. The previous explicit "Download SBOM Artifact" /
-      # "Copy SBOM to Assets Layout" steps relied on the per-job PackSignPublish_Pack_and_Sign_SBOM
-      # artifact, which Arcade no longer produces (SBOM moved to 1ES PT), causing the stage to fail.
+      # SBOM generation is handled by 1ES PT at publish time. Setting sbomEnabled: true on the
+      # 1ES.PublishPipelineArtifact task below makes 1ES generate an embedded _manifest SBOM over
+      # the published AssetsLayout (which includes the staged package). Downstream, the publish
+      # pipeline's release job validates this _manifest. The previous explicit "Download SBOM
+      # Artifact" / "Copy SBOM to Assets Layout" steps relied on the per-job
+      # PackSignPublish_Pack_and_Sign_SBOM artifact, which Arcade no longer produces (SBOM moved
+      # to 1ES PT).
       - template: /eng/pipelines/steps/publish-pipeline-artifact.yml@self
         parameters:
           displayName: 'Upload Assets Layout'
           targetPath: '$(System.ArtifactsDirectory)\AssetsLayout'
           artifact: 'StagingToolAssetsLayout'
+          sbomEnabled: true
           is1ESPipeline: ${{ parameters.is1ESPipeline }}
 
       # Only tag build from real release branches

--- a/eng/pipelines/steps/publish-pipeline-artifact.yml
+++ b/eng/pipelines/steps/publish-pipeline-artifact.yml
@@ -4,6 +4,8 @@ parameters:
   displayName: 'PublishPipelineArtifact'
   targetPath: ''
   artifact: ''
+  # When true, 1ES PT generates an embedded _manifest SBOM over the published artifact.
+  sbomEnabled: ''
   # Adjust for 1ES pipeline template
   is1ESPipeline: true
 
@@ -14,6 +16,8 @@ steps:
     inputs:
       targetPath: ${{ parameters.targetPath }}
       artifact: ${{ parameters.artifact }}
+      ${{ if ne(parameters.sbomEnabled, '') }}:
+        sbomEnabled: ${{ parameters.sbomEnabled }}
 - ${{ else }}:
   - task: PublishPipelineArtifact@1
     displayName: ${{ parameters.displayName }}


### PR DESCRIPTION
###### Summary

The release publish pipeline's manual approval step referenced `[TEAM FOUNDATION]\.NET Monitor Working Group`, which is obsolete and no longer resolves as an identity in dnceng. This meant the `ManualValidation` gate in `dotnet-monitor-publish.yml` had no valid approvers/notification target.

This updates both `notifyUsers` and `approvers` on the `ManualValidation@1` task to the new group's email alias `NETMonitor@service.microsoft.com`. Existence of the new group was validated against dnceng.visualstudio.com via the Identity Picker (it resolves to the Entra ID group `.NET Monitor`); the old working-group name returned no results.

Using the email alias rather than the `[TEAM FOUNDATION]\...` display-name form because this is an Entra ID backed group and the alias is the reliable resolver for the approval task.

###### Release Notes Entry